### PR TITLE
Initialize with mounted 'false'?

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 import { useRef, useEffect } from 'react';
 
 const useIsMounted = () => {
-  const isMounted = useRef(true);
-  useEffect(() => () => {
-    isMounted.current = false;
+  const isMounted = useRef(false);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => isMounted.current = false;
   }, []);
   return isMounted;
 };


### PR DESCRIPTION
IMHO when the hook runs for the first time, the component is not mounted already, so the initial value should be false.

Only after the (first) execution of useEffect the component is mounted and isMounted should change to true.

(Makes probably not a big difference in real life, but feels more correct)