### PR TITLE
Refactor package to node standard (CommonJS-like)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+const { useRef, useEffect } = require('react');
 
 const useIsMounted = () => {
   const isMounted = useRef(false);
@@ -9,4 +9,4 @@ const useIsMounted = () => {
   return isMounted;
 };
 
-export default useIsMounted;
+module.exports = useIsMounted;


### PR DESCRIPTION
Using `import` and `export` requires transpiling before publishing the package.
It works if transpiling is done on the use also, of course.
It is not always the case.
When I import it and run my React application through Webpack transformations, that is ok.
But when I run Jest agains my components, it fails on that main file because of the `import` statement.

The solution in this PR is cross-compatible. But if you want to keep the ES6 module syntax, you should transpile it for the npm registry.